### PR TITLE
Limit team size to seven members

### DIFF
--- a/src/components/TeamMaker.tsx
+++ b/src/components/TeamMaker.tsx
@@ -10,6 +10,8 @@ import { useToast } from '@/hooks/use-toast';
 import { Shuffle, Users, Sparkles, Edit3, Eye } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 
+const TEAM_SIZE = 7;
+
 export function TeamMaker() {
   const [members, setMembers] = useState<Member[]>([]);
   const [teamResult, setTeamResult] = useState<TeamDistributionResult | null>(null);
@@ -49,7 +51,7 @@ export function TeamMaker() {
       return;
     }
 
-    const result = generateBalancedTeams(members, 10);
+    const result = generateBalancedTeams(members, TEAM_SIZE);
     setTeamResult(result);
     
     toast({
@@ -62,7 +64,7 @@ export function TeamMaker() {
   const handleShuffleTeams = () => {
     if (members.length === 0) return;
     
-    const result = generateBalancedTeams(members, 10);
+    const result = generateBalancedTeams(members, TEAM_SIZE);
     setTeamResult(result);
     setIsInteractive(false);
     
@@ -206,7 +208,7 @@ export function TeamMaker() {
                   </div>
                   <h4 className="font-semibold text-foreground mb-2">Buat Tim</h4>
                   <p className="text-sm text-muted-foreground">
-                    Klik tombol "Buat Tim" untuk membagi data menjadi tim berisi 10 orang
+                    Klik tombol "Buat Tim" untuk membagi data menjadi tim berisi 7 orang
                   </p>
                 </div>
                 <div className="flex flex-col items-center text-center">

--- a/src/utils/teamGenerator.ts
+++ b/src/utils/teamGenerator.ts
@@ -1,6 +1,6 @@
 import { Member, Team, TeamDistributionResult } from '@/types/team';
 
-export function generateBalancedTeams(members: Member[], teamSize: number = 10): TeamDistributionResult {
+export function generateBalancedTeams(members: Member[], teamSize: number = 7): TeamDistributionResult {
   if (members.length === 0) {
     return { teams: [], totalMembers: 0, companies: [] };
   }
@@ -76,10 +76,14 @@ export function generateBalancedTeams(members: Member[], teamSize: number = 10):
           const aCount = a.team.companyDistribution[company];
           const bCount = b.team.companyDistribution[company];
           if (aCount !== bCount) return aCount - bCount;
-          
-          // Then prefer teams with more available space
-          const aSpace = teamSize - a.team.members.length;
-          const bSpace = teamSize - b.team.members.length;
+
+          // Then prefer teams with more available space considering remainder team size
+          const isRemainderTeamA = a.index === numTeams - 1 && remainder > 0;
+          const maxSizeA = isRemainderTeamA ? remainder : teamSize;
+          const isRemainderTeamB = b.index === numTeams - 1 && remainder > 0;
+          const maxSizeB = isRemainderTeamB ? remainder : teamSize;
+          const aSpace = maxSizeA - a.team.members.length;
+          const bSpace = maxSizeB - b.team.members.length;
           return bSpace - aSpace;
         });
 


### PR DESCRIPTION
## Summary
- Update team generator to default to seven-member teams and to respect actual capacity when balancing
- Use a shared constant for team size and revise instructions accordingly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 6 errors, 7 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bc9f1e5f4832e9a401274a43af699